### PR TITLE
feat: kq commitinorder support trace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/zeromicro/go-queue
+module github.com/zhuud/go-queue
 
 go 1.20
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/zhuud/go-queue
+module github.com/zeromicro/go-queue
 
 go 1.20
 

--- a/kq/pusher.go
+++ b/kq/pusher.go
@@ -30,6 +30,9 @@ type (
 		// kafka.Writer options
 		allowAutoTopicCreation bool
 		balancer               kafka.Balancer
+		batchTimeout           time.Duration
+		batchSize              int
+		batchBytes             int64
 
 		// executors.ChunkExecutor options
 		chunkSize     int
@@ -58,6 +61,15 @@ func NewPusher(addrs []string, topic string, opts ...PushOption) *Pusher {
 	producer.AllowAutoTopicCreation = options.allowAutoTopicCreation
 	if options.balancer != nil {
 		producer.Balancer = options.balancer
+	}
+	if options.batchTimeout > 0 {
+		producer.BatchTimeout = options.batchTimeout
+	}
+	if options.batchSize > 0 {
+		producer.BatchSize = options.batchSize
+	}
+	if options.batchBytes > 0 {
+		producer.BatchBytes = options.batchBytes
 	}
 
 	pusher := &Pusher{
@@ -176,5 +188,26 @@ func WithFlushInterval(interval time.Duration) PushOption {
 func WithSyncPush() PushOption {
 	return func(options *pushOptions) {
 		options.syncPush = true
+	}
+}
+
+// WithBatchTimeout customizes the Pusher with the given batch timeout.
+func WithBatchTimeout(timeout time.Duration) PushOption {
+	return func(options *pushOptions) {
+		options.batchTimeout = timeout
+	}
+}
+
+// WithBatchSize customizes the Pusher with the given batch size.
+func WithBatchSize(size int) PushOption {
+	return func(options *pushOptions) {
+		options.batchSize = size
+	}
+}
+
+// WithBatchBytes customizes the Pusher with the given batch bytes.
+func WithBatchBytes(bytes int64) PushOption {
+	return func(options *pushOptions) {
+		options.batchBytes = bytes
 	}
 }

--- a/kq/pusher_test.go
+++ b/kq/pusher_test.go
@@ -63,6 +63,39 @@ func TestNewPusher(t *testing.T) {
 		assert.NotNil(t, pusher)
 		assert.True(t, pusher.producer.(*kafka.Writer).AllowAutoTopicCreation)
 	})
+
+	t.Run("WithBatchTimeout", func(t *testing.T) {
+		timeout := 100 * time.Millisecond
+		pusher := NewPusher(addrs, topic, WithBatchTimeout(timeout))
+		assert.NotNil(t, pusher)
+		assert.Equal(t, timeout, pusher.producer.(*kafka.Writer).BatchTimeout)
+	})
+
+	t.Run("WithBatchSize", func(t *testing.T) {
+		size := 100
+		pusher := NewPusher(addrs, topic, WithBatchSize(size))
+		assert.NotNil(t, pusher)
+		assert.Equal(t, size, pusher.producer.(*kafka.Writer).BatchSize)
+	})
+
+	t.Run("WithBatchBytes", func(t *testing.T) {
+		bytes := int64(1024)
+		pusher := NewPusher(addrs, topic, WithBatchBytes(bytes))
+		assert.NotNil(t, pusher)
+		assert.Equal(t, bytes, pusher.producer.(*kafka.Writer).BatchBytes)
+	})
+
+	t.Run("WithMultipleBatchOptions", func(t *testing.T) {
+		timeout := 200 * time.Millisecond
+		size := 50
+		bytes := int64(2048)
+		pusher := NewPusher(addrs, topic, WithBatchTimeout(timeout), WithBatchSize(size), WithBatchBytes(bytes))
+		assert.NotNil(t, pusher)
+		writer := pusher.producer.(*kafka.Writer)
+		assert.Equal(t, timeout, writer.BatchTimeout)
+		assert.Equal(t, size, writer.BatchSize)
+		assert.Equal(t, bytes, writer.BatchBytes)
+	})
 }
 
 func TestPusher_Close(t *testing.T) {

--- a/kq/queue.go
+++ b/kq/queue.go
@@ -210,6 +210,11 @@ func (q *kafkaQueue) Stop() {
 }
 
 func (q *kafkaQueue) consumeOne(ctx context.Context, key, val string) error {
+	defer func() {
+		if err := recover(); err != nil {
+			logc.Errorf(ctx, "consumeOne failed recover, error: %v", err)
+		}
+	}()
 	startTime := timex.Now()
 	err := q.handler.Consume(ctx, key, val)
 	q.metrics.Add(stat.Task{

--- a/kq/queue_test.go
+++ b/kq/queue_test.go
@@ -196,3 +196,24 @@ func TestWithErrorHandler(t *testing.T) {
 	WithErrorHandler(handler)(options)
 	assert.NotNil(t, options.errorHandler)
 }
+
+func TestWithBatchTimeout(t *testing.T) {
+	options := &pushOptions{}
+	timeout := time.Second * 5
+	WithBatchTimeout(timeout)(options)
+	assert.Equal(t, timeout, options.batchTimeout)
+}
+
+func TestWithBatchSize(t *testing.T) {
+	options := &pushOptions{}
+	size := 100
+	WithBatchSize(size)(options)
+	assert.Equal(t, size, options.batchSize)
+}
+
+func TestWithBatchBytes(t *testing.T) {
+	options := &pushOptions{}
+	bytes := int64(1024)
+	WithBatchBytes(bytes)(options)
+	assert.Equal(t, bytes, options.batchBytes)
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-11-07 07:37:05 UTC

<h3>Greptile Summary</h3>


This review covers only the changes made since the last review, not the entire PR. The changes add new batch configuration options to the Kafka pusher functionality, providing users with more granular control over message batching behavior. Three new options are introduced: `batchTimeout`, `batchSize`, and `batchBytes`, which directly correspond to the underlying kafka-go library's batch configuration parameters. The implementation follows the existing pattern of configuration options in the codebase, with proper initialization logic and comprehensive test coverage. These additions enhance the pusher's performance tuning capabilities without affecting existing functionality.

<h3>Important Files Changed</h3>


| Filename | Score | Overview |
|----------|--------|----------|
| kq/pusher.go | 5/5 | Added three new batch configuration options (batchTimeout, batchSize, batchBytes) with corresponding option functions |
| kq/pusher_test.go | 5/5 | Added comprehensive test coverage for new batch options including individual and combined configuration tests |
| kq/queue_test.go | 5/5| Added unit tests for the new batch option functions to validate they properly set configuration values |

<h3>Confidence score: 5/5</h3>


- This PR is safe to merge with minimal risk as it adds optional configuration features without breaking existing behavior
- Score reflects clean implementation following established patterns with thorough test coverage and no breaking changes
- No files require special attention as all changes are additive and well-tested

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->