### PR TITLE
kq: 支持 kafka.Writer BatchTimeout/BatchSize/BatchBytes 配置

### DIFF
--- a/kq/pusher.go
+++ b/kq/pusher.go
@@ -30,6 +30,9 @@ type (
 		// kafka.Writer options
 		allowAutoTopicCreation bool
 		balancer               kafka.Balancer
+		batchTimeout           time.Duration
+		batchSize              int
+		batchBytes             int64
 
 		// executors.ChunkExecutor options
 		chunkSize     int
@@ -58,6 +61,15 @@ func NewPusher(addrs []string, topic string, opts ...PushOption) *Pusher {
 	producer.AllowAutoTopicCreation = options.allowAutoTopicCreation
 	if options.balancer != nil {
 		producer.Balancer = options.balancer
+	}
+	if options.batchTimeout > 0 {
+		producer.BatchTimeout = options.batchTimeout
+	}
+	if options.batchSize > 0 {
+		producer.BatchSize = options.batchSize
+	}
+	if options.batchBytes > 0 {
+		producer.BatchBytes = options.batchBytes
 	}
 
 	pusher := &Pusher{
@@ -176,5 +188,26 @@ func WithFlushInterval(interval time.Duration) PushOption {
 func WithSyncPush() PushOption {
 	return func(options *pushOptions) {
 		options.syncPush = true
+	}
+}
+
+// WithBatchTimeout customizes the Pusher with the given batch timeout.
+func WithBatchTimeout(timeout time.Duration) PushOption {
+	return func(options *pushOptions) {
+		options.batchTimeout = timeout
+	}
+}
+
+// WithBatchSize customizes the Pusher with the given batch size.
+func WithBatchSize(size int) PushOption {
+	return func(options *pushOptions) {
+		options.batchSize = size
+	}
+}
+
+// WithBatchBytes customizes the Pusher with the given batch bytes.
+func WithBatchBytes(bytes int64) PushOption {
+	return func(options *pushOptions) {
+		options.batchBytes = bytes
 	}
 }


### PR DESCRIPTION
- 新增 WithBatchTimeout 选项，支持配置批量发送超时时间
- 新增 WithBatchSize 选项，支持配置批量发送消息数量
- 新增 WithBatchBytes 选项，支持配置批量发送字节大小
- 补充完整的单元测试，覆盖单个配置和组合配置场景

涉及文件：
- kq/pusher.go: 添加三个配置选项和对应的 PushOption 函数
- kq/pusher_test.go: 添加对应的单元测试用例

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-11-07 08:35:18 UTC

<h3>Greptile Summary</h3>


This PR adds three new configuration options to the Kafka pusher component to expose native kafka-go writer batch configuration settings. The changes introduce `WithBatchTimeout`, `WithBatchSize`, and `WithBatchBytes` options that allow users to control when message batches are flushed based on time intervals, message counts, or byte sizes respectively. These new options follow the existing functional options pattern used throughout the `kq` package, maintaining consistency with other configuration functions like `WithBalancer` and `WithChunkSize`. The implementation adds the new fields to the `pushOptions` struct and applies them to the underlying `kafka.Writer` during initialization, only setting values when they are positive to avoid overriding defaults with zero values.

<h3>Important Files Changed</h3>


| Filename | Score | Overview |
|----------|-------|----------|
| kq/pusher.go | 4/5 | Adds three new batch configuration options with proper validation, but has a potential conflict where syncPush overrides batchSize |
| kq/pusher_test.go | 5/5 | Comprehensive test coverage for new batch options including individual, combined, and unit tests |

<h3>Confidence score: 4/5</h3>


- This PR introduces useful Kafka batch configuration options with minimal risk to existing functionality
- Score reduced by one point due to a potential configuration conflict where `syncPush` unconditionally overrides user-configured `batchSize`
- Pay close attention to the interaction between `WithSyncPush` and `WithBatchSize` options in kq/pusher.go

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Pusher
    participant kafka.Writer
    participant ChunkExecutor

    User->>Pusher: NewPusher(addrs, topic, opts)
    Pusher->>kafka.Writer: new kafka.Writer
    Note over Pusher: Apply batch options (timeout, size, bytes)
    alt syncPush enabled
        Note over Pusher: Set BatchSize=1, no ChunkExecutor
    else async push (default)
        Pusher->>ChunkExecutor: NewChunkExecutor with options
    end
    Pusher-->>User: return Pusher instance

    User->>Pusher: Push(ctx, value) or PushWithKey(ctx, key, value)
    Note over Pusher: Create kafka.Message with key/value
    Note over Pusher: Inject trace context via OpenTelemetry
    
    alt has ChunkExecutor (async)
        Pusher->>ChunkExecutor: Add(msg, len(value))
        Note over ChunkExecutor: Buffer messages until batch ready
        ChunkExecutor->>kafka.Writer: WriteMessages(ctx, batch...)
    else no ChunkExecutor (sync)
        Pusher->>kafka.Writer: WriteMessages(ctx, msg)
    end
    
    kafka.Writer-->>Pusher: return error/nil
    Pusher-->>User: return error/nil

    User->>Pusher: Close()
    alt has ChunkExecutor
        Pusher->>ChunkExecutor: Flush()
        ChunkExecutor->>kafka.Writer: WriteMessages(ctx, remaining_batch...)
    end
    Pusher->>kafka.Writer: Close()
    kafka.Writer-->>Pusher: return error/nil
    Pusher-->>User: return error/nil
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->