### PR TITLE
kq: 支持 kafka.Writer BatchTimeout/BatchBytes 配置

### DIFF
--- a/kq/pusher.go
+++ b/kq/pusher.go
@@ -30,6 +30,9 @@ type (
 		// kafka.Writer options
 		allowAutoTopicCreation bool
 		balancer               kafka.Balancer
+		batchTimeout           time.Duration
+		batchSize              int
+		batchBytes             int64
 
 		// executors.ChunkExecutor options
 		chunkSize     int
@@ -58,6 +61,15 @@ func NewPusher(addrs []string, topic string, opts ...PushOption) *Pusher {
 	producer.AllowAutoTopicCreation = options.allowAutoTopicCreation
 	if options.balancer != nil {
 		producer.Balancer = options.balancer
+	}
+	if options.batchTimeout > 0 {
+		producer.BatchTimeout = options.batchTimeout
+	}
+	if options.batchSize > 0 {
+		producer.BatchSize = options.batchSize
+	}
+	if options.batchBytes > 0 {
+		producer.BatchBytes = options.batchBytes
 	}
 
 	pusher := &Pusher{
@@ -176,5 +188,26 @@ func WithFlushInterval(interval time.Duration) PushOption {
 func WithSyncPush() PushOption {
 	return func(options *pushOptions) {
 		options.syncPush = true
+	}
+}
+
+// WithBatchTimeout customizes the Pusher with the given batch timeout.
+func WithBatchTimeout(timeout time.Duration) PushOption {
+	return func(options *pushOptions) {
+		options.batchTimeout = timeout
+	}
+}
+
+// WithBatchSize customizes the Pusher with the given batch size.
+func WithBatchSize(size int) PushOption {
+	return func(options *pushOptions) {
+		options.batchSize = size
+	}
+}
+
+// WithBatchBytes customizes the Pusher with the given batch bytes.
+func WithBatchBytes(bytes int64) PushOption {
+	return func(options *pushOptions) {
+		options.batchBytes = bytes
 	}
 }

--- a/kq/pusher.go
+++ b/kq/pusher.go
@@ -31,7 +31,6 @@ type (
 		allowAutoTopicCreation bool
 		balancer               kafka.Balancer
 		batchTimeout           time.Duration
-		batchSize              int
 		batchBytes             int64
 
 		// executors.ChunkExecutor options
@@ -64,9 +63,6 @@ func NewPusher(addrs []string, topic string, opts ...PushOption) *Pusher {
 	}
 	if options.batchTimeout > 0 {
 		producer.BatchTimeout = options.batchTimeout
-	}
-	if options.batchSize > 0 {
-		producer.BatchSize = options.batchSize
 	}
 	if options.batchBytes > 0 {
 		producer.BatchBytes = options.batchBytes
@@ -195,13 +191,6 @@ func WithSyncPush() PushOption {
 func WithBatchTimeout(timeout time.Duration) PushOption {
 	return func(options *pushOptions) {
 		options.batchTimeout = timeout
-	}
-}
-
-// WithBatchSize customizes the Pusher with the given batch size.
-func WithBatchSize(size int) PushOption {
-	return func(options *pushOptions) {
-		options.batchSize = size
 	}
 }
 

--- a/kq/pusher_test.go
+++ b/kq/pusher_test.go
@@ -71,13 +71,6 @@ func TestNewPusher(t *testing.T) {
 		assert.Equal(t, timeout, pusher.producer.(*kafka.Writer).BatchTimeout)
 	})
 
-	t.Run("WithBatchSize", func(t *testing.T) {
-		batchSize := 100
-		pusher := NewPusher(addrs, topic, WithBatchSize(batchSize))
-		assert.NotNil(t, pusher)
-		assert.Equal(t, batchSize, pusher.producer.(*kafka.Writer).BatchSize)
-	})
-
 	t.Run("WithBatchBytes", func(t *testing.T) {
 		batchBytes := int64(1024 * 1024) // 1MB
 		pusher := NewPusher(addrs, topic, WithBatchBytes(batchBytes))
@@ -87,13 +80,11 @@ func TestNewPusher(t *testing.T) {
 
 	t.Run("WithMultipleBatchOptions", func(t *testing.T) {
 		timeout := time.Second * 3
-		batchSize := 50
 		batchBytes := int64(512 * 1024) // 512KB
-		pusher := NewPusher(addrs, topic, WithBatchTimeout(timeout), WithBatchSize(batchSize), WithBatchBytes(batchBytes))
+		pusher := NewPusher(addrs, topic, WithBatchTimeout(timeout), WithBatchBytes(batchBytes))
 		assert.NotNil(t, pusher)
 		writer := pusher.producer.(*kafka.Writer)
 		assert.Equal(t, timeout, writer.BatchTimeout)
-		assert.Equal(t, batchSize, writer.BatchSize)
 		assert.Equal(t, batchBytes, writer.BatchBytes)
 	})
 }
@@ -178,13 +169,6 @@ func TestWithBatchTimeout(t *testing.T) {
 	timeout := time.Second * 5
 	WithBatchTimeout(timeout)(options)
 	assert.Equal(t, timeout, options.batchTimeout)
-}
-
-func TestWithBatchSize(t *testing.T) {
-	options := &pushOptions{}
-	batchSize := 100
-	WithBatchSize(batchSize)(options)
-	assert.Equal(t, batchSize, options.batchSize)
 }
 
 func TestWithBatchBytes(t *testing.T) {


### PR DESCRIPTION
kq: 支持 kafka.Writer BatchTimeout/BatchBytes 配置
- 新增 WithBatchTimeout 选项，支持配置批量发送超时时间
- 新增 WithBatchBytes 选项，支持配置批量发送字节大小
- 补充完整的单元测试，覆盖单个配置和组合配置场景

涉及文件：
- kq/pusher.go: 添加两个配置选项和对应的 PushOption 函数
- kq/pusher_test.go: 添加对应的单元测试用例

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-11-10 06:45:25 UTC

<h3>Greptile Summary</h3>


This PR enhances the Kafka queue (`kq`) package by adding support for two critical Kafka writer batch configuration options: `BatchTimeout` and `BatchBytes`. The changes introduce `WithBatchTimeout()` and `WithBatchBytes()` configuration functions that allow users to fine-tune Kafka message batching behavior for performance optimization.

The implementation follows the existing functional options pattern used throughout the codebase. Two new fields are added to the `pushOptions` struct (`batchTimeout` and `batchBytes`), and the `NewPusher()` function applies these configurations to the underlying `kafka.Writer` with proper zero-value validation. This allows users to control both the maximum time to wait before sending a batch (`BatchTimeout`) and the maximum batch size in bytes (`BatchBytes`), which are essential parameters for balancing throughput and latency in Kafka message production.

The changes are well-integrated with the existing architecture and maintain backward compatibility by using zero-value checks before applying the new configurations.

<h3>Important Files Changed</h3>


| Filename | Score | Overview |
|----------|-------|-----------|
| kq/pusher.go | 4/5 | Added BatchTimeout and BatchBytes configuration support with proper validation |
| kq/pusher_test.go | 5/5 | Added comprehensive unit tests for new batch configuration options |

<h3>Confidence score: 4/5</h3>


- This PR is safe to merge with low risk of production issues
- Score reflects solid implementation following established patterns, but minor concerns about validation logic and potential edge cases with zero/negative values
- Pay close attention to the validation logic in pusher.go to ensure proper handling of edge cases

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Pusher
    participant KafkaWriter
    participant ChunkExecutor

    User->>+Pusher: NewPusher(addrs, topic, WithBatchTimeout(), WithBatchBytes())
    Pusher->>Pusher: "Create kafka.Writer with addresses and topic"
    Pusher->>Pusher: "Apply batch timeout and batch bytes options"
    Pusher->>+ChunkExecutor: "Create ChunkExecutor (if not sync mode)"
    ChunkExecutor-->>-Pusher: "Return executor"
    Pusher-->>-User: "Return Pusher instance"

    User->>+Pusher: Push(ctx, value)
    Pusher->>Pusher: "Generate timestamp key"
    Pusher->>+Pusher: PushWithKey(ctx, key, value)
    Pusher->>Pusher: "Create kafka.Message with key and value"
    Pusher->>Pusher: "Inject trace context into message"
    alt executor exists (async mode)
        Pusher->>+ChunkExecutor: Add(message, messageSize)
        ChunkExecutor-->>-Pusher: "Return error or nil"
    else sync mode
        Pusher->>+KafkaWriter: WriteMessages(ctx, message)
        KafkaWriter-->>-Pusher: "Return error or nil"
    end
    Pusher-->>-Pusher: "Return result"
    Pusher-->>-User: "Return error or nil"

    Note over ChunkExecutor, KafkaWriter: "ChunkExecutor batches messages and flushes to KafkaWriter"
    ChunkExecutor->>+KafkaWriter: WriteMessages(ctx, batchedMessages)
    KafkaWriter-->>-ChunkExecutor: "Return error or nil"

    User->>+Pusher: Close()
    alt executor exists
        Pusher->>+ChunkExecutor: Flush()
        ChunkExecutor-->>-Pusher: "Complete pending writes"
    end
    Pusher->>+KafkaWriter: Close()
    KafkaWriter-->>-Pusher: "Return error or nil"
    Pusher-->>-User: "Return error or nil"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->