### PR TITLE
Use configured stream name for JetStream consumer

### DIFF
--- a/natsq/consumer.go
+++ b/natsq/consumer.go
@@ -133,7 +133,7 @@ func (cm *ConsumerManager) subscribe(queue ConsumerQueue) {
 	ctx := context.Background()
 	if cm.mode == NatJetMode {
 		js, _ := jetstream.New(cm.conn)
-		stream, err := js.Stream(ctx, "ccc")
+		stream, err := js.Stream(ctx, queue.StreamName)
 		if err != nil {
 			log.Fatalf("Error creating stream: %v", err)
 			return


### PR DESCRIPTION
- What: Replace hardcoded stream name with queue.StreamName when fetching JetStream stream.
- Why: Ensure consumers use the stream specified by configuration instead of a fixed placeholder.
- Impact: Fixes incorrect stream selection in JetStream mode; no behavior change for default NATS mode.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Fixes hardcoded stream name "ccc" in JetStream consumer by using the configured `queue.StreamName` value instead
- Ensures JetStream consumers connect to the stream specified in configuration rather than a placeholder value
- Makes the existing stream name validation meaningful since the configured value is now actually used

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| `natsq/consumer.go` | Fixed JetStream stream fetching to use configured stream name instead of hardcoded "ccc" placeholder |

<h3>Confidence score: 5/5</h3>


- This PR is safe to merge with minimal risk as it fixes a clear bug with a straightforward solution
- Score reflects a simple one-line fix that replaces hardcoded placeholder value with proper configuration usage
- No files require special attention beyond the single line change in the consumer implementation

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ConsumerManager
    participant NATS
    participant JetStream
    participant Consumer
    
    User->>ConsumerManager: "MustNewConsumerManager(cfg, queues, mode)"
    ConsumerManager->>NATS: "Connect(serverUri, options)"
    NATS-->>ConsumerManager: "connection"
    ConsumerManager->>ConsumerManager: "registerQueue(queue)"
    
    User->>ConsumerManager: "Start()"
    ConsumerManager->>ConsumerManager: "subscribe(queue)"
    
    alt NatJetMode
        ConsumerManager->>JetStream: "New(conn)"
        JetStream-->>ConsumerManager: "jetstream instance"
        ConsumerManager->>JetStream: "Stream(ctx, queue.StreamName)"
        JetStream-->>ConsumerManager: "stream"
        ConsumerManager->>JetStream: "CreateOrUpdateConsumer(ctx, config)"
        JetStream-->>ConsumerManager: "consumer"
        ConsumerManager->>JetStream: "Consume(handleFunc, options)"
        JetStream->>Consumer: "HandleMessage(msg)"
        Consumer-->>JetStream: "result"
        JetStream->>JetStream: "Ack()"
    else NatDefaultMode
        ConsumerManager->>NATS: "QueueSubscribe(subject, queueName, handleFunc)"
        NATS->>Consumer: "HandleMessage(msg)"
        Consumer-->>NATS: "result"
        NATS->>NATS: "Ack()"
    end
    
    User->>ConsumerManager: "Stop()"
    ConsumerManager->>NATS: "Close()"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->