### PR TITLE
Add NATS JetStream OTel propagation support

### DIFF
--- a/example/natsmq/consumer/consumer.go
+++ b/example/natsmq/consumer/consumer.go
@@ -1,17 +1,19 @@
 package main
 
 import (
+	"context"
 	"flag"
-	"github.com/nats-io/nats.go"
-	"github.com/nats-io/nats.go/jetstream"
-	"github.com/zeromicro/go-queue/natsmq/common"
-	"github.com/zeromicro/go-queue/natsmq/consumer"
-	"github.com/zeromicro/go-zero/core/conf"
 	"log"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/zeromicro/go-queue/natsmq/common"
+	"github.com/zeromicro/go-queue/natsmq/consumer"
+	"github.com/zeromicro/go-zero/core/conf"
 )
 
 var configFile = flag.String("f", "config.yaml", "Specify the config file")
@@ -28,7 +30,7 @@ type NatsConf struct {
 
 type MyConsumeHandler struct{}
 
-func (h *MyConsumeHandler) Consume(msg jetstream.Msg) error {
+func (h *MyConsumeHandler) Consume(ctx context.Context, msg jetstream.Msg) error {
 	log.Printf("subject [%s] Received message: %s", msg.Subject(), string(msg.Data()))
 	return nil
 }

--- a/natsmq/consumer/config.go
+++ b/natsmq/consumer/config.go
@@ -1,8 +1,10 @@
 package consumer
 
 import (
-	"github.com/nats-io/nats.go/jetstream"
+	"context"
 	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
 )
 
 // ConsumerConfig combines core consumer settings with advanced parameters.
@@ -59,5 +61,5 @@ const (
 // ConsumeHandler defines an interface for message processing.
 // Users need to implement the Consume method to handle individual messages.
 type ConsumeHandler interface {
-	Consume(msg jetstream.Msg) error
+	Consume(ctx context.Context, msg jetstream.Msg) error
 }

--- a/natsmq/internal/trace.go
+++ b/natsmq/internal/trace.go
@@ -1,0 +1,49 @@
+package internal
+
+import (
+	"github.com/nats-io/nats.go"
+	"go.opentelemetry.io/otel/propagation"
+)
+
+var _ propagation.TextMapCarrier = (*HeaderCarrier)(nil)
+
+// HeaderCarrier injects and extracts traces from NATS headers.
+type HeaderCarrier struct {
+	headers *nats.Header
+}
+
+// NewHeaderCarrier returns a new HeaderCarrier.
+func NewHeaderCarrier(headers *nats.Header) HeaderCarrier {
+	return HeaderCarrier{headers: headers}
+}
+
+// Get returns the value associated with the passed key.
+func (h HeaderCarrier) Get(key string) string {
+	if h.headers == nil || *h.headers == nil {
+		return ""
+	}
+	return (*h.headers).Get(key)
+}
+
+// Set stores the key-value pair.
+func (h HeaderCarrier) Set(key string, value string) {
+	if h.headers == nil {
+		return
+	}
+	if *h.headers == nil {
+		*h.headers = nats.Header{}
+	}
+	(*h.headers).Set(key, value)
+}
+
+// Keys lists the keys stored in this carrier.
+func (h HeaderCarrier) Keys() []string {
+	if h.headers == nil || *h.headers == nil {
+		return []string{}
+	}
+	out := make([]string, 0, len(*h.headers))
+	for key := range *h.headers {
+		out = append(out, key)
+	}
+	return out
+}

--- a/natsmq/internal/trace_test.go
+++ b/natsmq/internal/trace_test.go
@@ -38,6 +38,16 @@ func TestHeaderCarrierGet(t *testing.T) {
 	}
 }
 
+func TestHeaderCarrierWithNilPointer(t *testing.T) {
+	carrier := NewHeaderCarrier(nil)
+
+	assert.Equal(t, "", carrier.Get("foo"))
+
+	carrier.Set("foo", "bar")
+
+	assert.Equal(t, []string{}, carrier.Keys())
+}
+
 func TestHeaderCarrierSet(t *testing.T) {
 	var headers nats.Header
 	carrier := NewHeaderCarrier(&headers)

--- a/natsmq/internal/trace_test.go
+++ b/natsmq/internal/trace_test.go
@@ -1,0 +1,89 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHeaderCarrierGet(t *testing.T) {
+	testCases := []struct {
+		name     string
+		carrier  HeaderCarrier
+		key      string
+		expected string
+	}{
+		{
+			name: "exists",
+			carrier: NewHeaderCarrier(&nats.Header{
+				"foo": []string{"bar"},
+			}),
+			key:      "foo",
+			expected: "bar",
+		},
+		{
+			name:     "not exists",
+			carrier:  NewHeaderCarrier(&nats.Header{}),
+			key:      "foo",
+			expected: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.carrier.Get(tc.key)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestHeaderCarrierSet(t *testing.T) {
+	var headers nats.Header
+	carrier := NewHeaderCarrier(&headers)
+
+	carrier.Set("foo", "bar")
+	carrier.Set("foo", "bar2")
+	carrier.Set("foo2", "bar3")
+
+	assert.Equal(t, nats.Header{
+		"foo":  []string{"bar2"},
+		"foo2": []string{"bar3"},
+	}, headers)
+}
+
+func TestHeaderCarrierKeys(t *testing.T) {
+	testCases := []struct {
+		name     string
+		carrier  HeaderCarrier
+		expected []string
+	}{
+		{
+			name: "one",
+			carrier: NewHeaderCarrier(&nats.Header{
+				"foo": []string{"bar"},
+			}),
+			expected: []string{"foo"},
+		},
+		{
+			name:     "none",
+			carrier:  NewHeaderCarrier(&nats.Header{}),
+			expected: []string{},
+		},
+		{
+			name: "many",
+			carrier: NewHeaderCarrier(&nats.Header{
+				"foo": []string{"bar"},
+				"baz": []string{"quux"},
+			}),
+			expected: []string{"foo", "baz"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.carrier.Keys()
+			assert.ElementsMatch(t, tc.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
- Add header carrier and tests for NATS headers
- Inject trace context on publish and extract on consume
- Expose PublishMsg for full nats.Msg support

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Adds OpenTelemetry trace propagation support for NATS JetStream, enabling distributed tracing across NATS message boundaries.

- Implemented `HeaderCarrier` to bridge NATS headers with OTel's `TextMapCarrier` interface
- Modified publisher to inject trace context into message headers via new `PublishMsg` and `PublishWithHeaders` methods
- Updated consumer to extract trace context from headers and pass it to message handlers
- Changed `ConsumeHandler` interface signature to accept `context.Context` (breaking change for existing implementations)
- Updated example to demonstrate the new context-aware handler pattern
- Follows the same implementation pattern as the existing Kafka queue (`kq`) for consistency

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- Clean implementation with comprehensive tests, follows established patterns from kq package, proper nil handling in HeaderCarrier, and includes updated example code
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| natsmq/internal/trace.go | Added HeaderCarrier to propagate OTel trace context through NATS headers |
| natsmq/publisher/publisher.go | Added trace injection via PublishMsg and PublishWithHeaders methods |
| natsmq/consumer/consumer.go | Added trace extraction in ackMessage, passing context to consumer handlers |
| natsmq/consumer/config.go | Updated ConsumeHandler interface to accept context for trace propagation |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Publisher
    participant OTel as OTel Propagator
    participant HeaderCarrier
    participant NATS
    participant Consumer
    participant Handler as ConsumeHandler

    Publisher->>HeaderCarrier: NewHeaderCarrier(&msg.Header)
    Publisher->>OTel: Inject(ctx, carrier)
    OTel->>HeaderCarrier: Set(key, value)
    HeaderCarrier->>NATS: msg.Header updated
    Publisher->>NATS: PublishMsg(ctx, msg)
    
    NATS->>Consumer: Message delivered
    Consumer->>HeaderCarrier: NewHeaderCarrier(&headers)
    Consumer->>OTel: Extract(ctx, carrier)
    OTel->>HeaderCarrier: Get(key)
    HeaderCarrier-->>OTel: trace context values
    OTel-->>Consumer: ctx with trace
    Consumer->>Consumer: contextx.ValueOnlyFrom(ctx)
    Consumer->>Handler: Consume(ctx, msg)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->